### PR TITLE
Enabling to pass in options as a part of http request object

### DIFF
--- a/lib/getRequest.js
+++ b/lib/getRequest.js
@@ -35,7 +35,7 @@ function getReq(config) {
         options.headers.accept = options.headers.accept || 'text/html,application/xhtml+xml,application/xml,application/json';
         options.headers['user-agent'] = options.headers['user-agent'] || 'Reliable-Get-Request-Agent';
 
-        requestWithDefault({ url: options.url, timeout: options.timeout, headers: options.headers })
+        requestWithDefault(options)
         .on('error', function (err) {
             inErrorState = true;
             next(new HTTPError(formatError(err.message)));

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,8 @@ var options = {
   }
 ```
 
+The `options` object is fully passed down to the request.
+
 Configuration
 =============
 

--- a/tests/reliable-get.test.js
+++ b/tests/reliable-get.test.js
@@ -25,6 +25,17 @@ describe("Reliable Get", function() {
       });
   });
 
+  it('OPTIONS OBJECT: should fully pass OPTIONS object down to the request', function (done) {
+      var config = {cache: {engine: 'nocache'}};
+      var rg = new ReliableGet(config);
+      rg.get({url: 'http://localhost:' + TEST_SERVER_PORT, qs: { 'key': 'value' } }, function (err, response) {
+          expect(err).to.be(null);
+          expect(response.statusCode).to.be(200);
+          expect(response.request.uri.query).to.be('key=value');
+          done();
+      });
+  });
+
   it('NO CACHE: should fail with an invalid url', function(done) {
       var config = {cache:{engine:'nocache'}};
       var rg = new ReliableGet(config);


### PR DESCRIPTION
- so that we can pass in Http options like qs while hitting iSite api

Note: In order to pass all the tests, you need to install `redis` and `memcached` locally and started them as well.